### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -2,7 +2,7 @@
 import stripe
 import json
 import os
-
+import logging
 from flask import Flask, render_template, jsonify, request, send_from_directory, redirect
 from dotenv import load_dotenv, find_dotenv
 
@@ -17,6 +17,7 @@ stripe.set_app_info(
 stripe.api_version = '2020-08-27'
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 
+logging.basicConfig(level=logging.ERROR)
 static_dir = str(os.path.abspath(os.path.join(__file__ , "..", os.getenv("STATIC_DIR"))))
 app = Flask(__name__, static_folder=static_dir, static_url_path="", template_folder=static_dir)
 
@@ -79,7 +80,8 @@ def create_payment():
     except stripe.error.StripeError as e:
         return jsonify({'error': {'message': str(e)}}), 400
     except Exception as e:
-        return jsonify({'error': {'message': str(e)}}), 400
+        logging.error("An error occurred: %s", str(e))
+        return jsonify({'error': {'message': "An internal error has occurred!"}}), 400
 
 @app.route('/payment/next', methods=['GET'])
 def get_payment_next():


### PR DESCRIPTION
Potential fix for [https://github.com/ellipsis52/accept-a-payment-on-webtechnicom/security/code-scanning/2](https://github.com/ellipsis52/accept-a-payment-on-webtechnicom/security/code-scanning/2)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

Specifically, we will:
1. Import the `logging` module to log the exceptions.
2. Configure the logging settings.
3. Modify the exception handling code to log the detailed exception message and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
